### PR TITLE
Added cronjob for auto closing overdue polls

### DIFF
--- a/Backend/Application/Application.csproj
+++ b/Backend/Application/Application.csproj
@@ -10,7 +10,8 @@
 		<PackageReference Include="MediatR" Version="11.0.0" />
 		<PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.10" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.4.0"/>
+    <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
+    <PackageReference Include="Sgbj.Cron.CronTimer" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Database\Database.csproj" />

--- a/Backend/Application/Commands/CloseExpiredPollsCommand.cs
+++ b/Backend/Application/Commands/CloseExpiredPollsCommand.cs
@@ -1,0 +1,24 @@
+﻿using Application.Repositories;
+using MediatR;
+
+namespace Application.Commands
+{
+    public class CloseExpiredPollsCommand : IRequest<int>
+    {
+        public CloseExpiredPollsCommand() { }
+    }
+    public class CloseExpiredPollsCommandHandler : IRequestHandler<CloseExpiredPollsCommand, int>
+    {
+        private readonly IPollRepository _pollRepository;
+
+        public CloseExpiredPollsCommandHandler(IPollRepository pollRepository)
+        {
+            _pollRepository = pollRepository;
+        }
+
+        public async Task<int> Handle(CloseExpiredPollsCommand command, CancellationToken token)
+        {
+            return await _pollRepository.CloseExpiredPolls();
+        }
+    }
+}

--- a/Backend/Application/Cronjobs/ClosePolls.cs
+++ b/Backend/Application/Cronjobs/ClosePolls.cs
@@ -1,0 +1,31 @@
+﻿using Application.Commands;
+using Cronos;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Sgbj.Cron;
+
+namespace Application.Cronjobs
+{
+    public class ClosePolls : BackgroundService
+    {
+        private readonly IServiceScopeFactory _serviceScopeFactory;
+        public ClosePolls(IServiceScopeFactory serviceScopeFactory) : base()
+        {
+            _serviceScopeFactory = serviceScopeFactory;
+        }
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            using var scope = _serviceScopeFactory.CreateScope();
+            var mediatR = scope.ServiceProvider.GetService<IMediator>();
+            // Every minute
+            using var timer = new CronTimer(CronExpression.Parse("* * * * *"));
+
+            while (await timer.WaitForNextTickAsync(stoppingToken))
+            {
+                var res = await mediatR.Send(new CloseExpiredPollsCommand());
+                Console.WriteLine($"Autoclosed {res} polls");
+            }
+        }
+    }
+}

--- a/Backend/Application/DependencyInjection.cs
+++ b/Backend/Application/DependencyInjection.cs
@@ -1,4 +1,6 @@
-﻿using Application.Extentions;
+﻿using Application.Cronjobs;
+using Application.Extentions;
+using Application.Messaging;
 using Application.Repositories;
 using Domain.Entities;
 using IdGen.DependencyInjection;
@@ -22,8 +24,9 @@ namespace Application
             services.AddTransient<IIotDeviceRepository, IoTDeviceRepository>();
             services.AddTransient<UserManager<User>>();
             services.AddTransient<IGenericExtension, GenericExtensions>();
-
+            services.AddSingleton<RabbitMQClient>();
             services.AddIdGen(39);
+            services.AddHostedService<ClosePolls>();
 
             return services;
         }

--- a/Backend/Application/Messaging/RabbitMQClient.cs
+++ b/Backend/Application/Messaging/RabbitMQClient.cs
@@ -1,9 +1,7 @@
-using System;
-using System.Text;
 using Domain.Entities;
 using RabbitMQ.Client;
+using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 
 namespace Application.Messaging
@@ -58,7 +56,7 @@ namespace Application.Messaging
 
             _channel.BasicPublish(exchange: "",
                 routingKey: "polls",
-                basicProperties: basicProperties, 
+                basicProperties: basicProperties,
                 body: body);
             Console.WriteLine(" [x] Sent {0}", Convert.ToString(json));
         }


### PR DESCRIPTION
Cronjob runs once every minute, which essentially means that as a worst case scenario a user can vote on a poll 59seconds after its supposed to be closed. Can add a check in /api/vote if the poll endtime is less than current time as well if we deem this necessary.