### PR TITLE
GetServedPolls endpoint, change serve poll

### DIFF
--- a/Backend/Application/Queries/GetServedPollQuery.cs
+++ b/Backend/Application/Queries/GetServedPollQuery.cs
@@ -1,0 +1,30 @@
+﻿using Application.DTO.PollDTOs;
+using Application.Repositories;
+using MediatR;
+
+namespace Application.Queries
+{
+    public class GetServedPollQuery : IRequest<List<GetPollDTO>>
+    {
+        public readonly Guid _id;
+
+        public GetServedPollQuery(Guid id)
+        {
+            _id = id;
+        }
+    }
+    public class GetServedPollsCommandHandler : IRequestHandler<GetServedPollQuery, List<GetPollDTO>>
+    {
+        private readonly IIotDeviceRepository _iotRepository;
+
+        public GetServedPollsCommandHandler(IIotDeviceRepository iotRepository)
+        {
+            _iotRepository = iotRepository;
+        }
+
+        public async Task<List<GetPollDTO>> Handle(GetServedPollQuery command, CancellationToken token)
+        {
+            return await _iotRepository.GetServedPolls(command._id);
+        }
+    }
+}


### PR DESCRIPTION
Added an endpoint for getting all polls served to an IoT device, GET /api/iot/servedPolls/{deviceId}. Added logic to the existing endpoint for serving polls to check if the poll is closed or private, we now only allow open and public polls to be served to IoT devices. Changed the structure of this endpoint from having IoT device id in api path and pollid in request body to making the request go to /api/IoT/{IoTId}/{pollId} with an empty request body.