### PR TITLE
Iot device/fix errors

### DIFF
--- a/Backend/API/Controllers/IoTDeviceController.cs
+++ b/Backend/API/Controllers/IoTDeviceController.cs
@@ -137,5 +137,28 @@ namespace API.Controllers
             }
             return Ok(result);
         }
+
+        [HttpPost("servedPolls/{IoTId}/{pollId}")]
+        public async Task<ActionResult<int>> removeServedPollByPollId(Guid IoTId, string pollId)
+        {
+            var result = await Mediator.Send(new RemoveServedPollCommand(IoTId, pollId));
+            if (result == -1)
+            {
+                return Problem(
+                    title: "IoT device not found.",
+                    detail: $"IoT device with id {IoTId} not found.",
+                    statusCode: StatusCodes.Status400BadRequest
+                    );
+            }
+            if (result == -2)
+            {
+                return Problem(
+                    title: "Poll id not found in queue for IoT device.",
+                    detail: $"Poll id with id {pollId} was not served to IoT device with id {IoTId}.",
+                    statusCode: StatusCodes.Status400BadRequest
+                    );
+            }
+            return Ok(result);
+        }
     }
 }

--- a/Backend/API/Controllers/PollController.cs
+++ b/Backend/API/Controllers/PollController.cs
@@ -119,6 +119,7 @@ namespace API.Controllers
         [HttpPut("{Id}/close")]
         [ProducesResponseType(200)]
         [ProducesResponseType(403)]
+        [ProducesResponseType(404)]
         public async Task<ActionResult<int>> closePoll(string Id)
         {
             var result = await Mediator.Send(new ClosePollCommand(Id));
@@ -139,7 +140,7 @@ namespace API.Controllers
                     );
             }
             //_rabbitMQClient.PublishClosePoll(result);
-            return result == 1 ? Ok($"Poll {Id} closed.") : new BadRequestObjectResult(result);
+            return result >= 1 ? Ok($"Poll {Id} closed.") : new BadRequestObjectResult(result);
         }
 
         /// <summary>

--- a/Backend/Application/Commands/RemoveServedPollCommand.cs
+++ b/Backend/Application/Commands/RemoveServedPollCommand.cs
@@ -1,0 +1,31 @@
+﻿using Application.Repositories;
+using MediatR;
+
+namespace Application.Commands
+{
+    public class RemoveServedPollCommand : IRequest<int>
+    {
+        public readonly Guid _ioTId;
+        public readonly string _pollId;
+
+        public RemoveServedPollCommand(Guid IoTId, string pollId)
+        {
+            _ioTId = IoTId;
+            _pollId = pollId;
+        }
+    }
+    public class RemoveServedPollCommandHandler : IRequestHandler<RemoveServedPollCommand, int>
+    {
+        private readonly IIotDeviceRepository _iotRepository;
+
+        public RemoveServedPollCommandHandler(IIotDeviceRepository iotRepository)
+        {
+            _iotRepository = iotRepository;
+        }
+
+        public async Task<int> Handle(RemoveServedPollCommand command, CancellationToken token)
+        {
+            return await _iotRepository.RemoveServedPoll(command._ioTId, command._pollId);
+        }
+    }
+}

--- a/iot/.env
+++ b/iot/.env
@@ -1,0 +1,1 @@
+VITE_BASE_URL = 'https://localhost:7280/api/'

--- a/iot/.env.development
+++ b/iot/.env.development
@@ -1,1 +1,0 @@
-BASE_URL = 'https://localhost:7280/api/'

--- a/iot/.env.production
+++ b/iot/.env.production
@@ -1,0 +1,1 @@
+VITE_BASE_URL = 'https://feedapplication.azurewebsites.net/api/'

--- a/iot/.gitignore
+++ b/iot/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 dist
-.env

--- a/iot/src/components/Poll.css
+++ b/iot/src/components/Poll.css
@@ -3,14 +3,19 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    height: 100%;
-    width: 75%;
-    height: 100vh;
-    padding-left: 13%;
-    padding-bottom: 10%;
-    /* background-color: bisque; */
+    height: 100%;   
+    height: 100vh;  
+    font-size: 8px;
+    color: rgb(128, 128, 128);
 }
-
+.device-id {
+    font-weight: normal;
+    margin-bottom: 0px;
+}
+.device-name {
+    font-weight: normal;
+    margin-bottom: 0px;
+}
 .poll-form {
     display: flex;
     flex-direction: column;
@@ -18,10 +23,16 @@
     justify-content: center;
     height: 100%;
     width: 100%;
-    background-color: bisque;
 }
 
 .poll-text {
+    font-size: 40px;
+    color: #bdbdbd;
     margin-top: 50px;
+}
+
+.poll-question {
     font-size: 50px;
+    color: #e6e6e6;
+    margin-top: -30px;
 }

--- a/iot/src/components/Poll.tsx
+++ b/iot/src/components/Poll.tsx
@@ -11,10 +11,10 @@ const Poll:Component = () => {
             <div class="container">
             <div class="poll">
                 <div class="poll-form">
-                    <h1 class='text-center'> IoT Device ID: {iot_device()["deviceID"]} </h1>
-                    <h1 class='text-center'> IoT Device Name: {iot_device()["deviceName"]} </h1>
+                    <h1 class='device-id'><b>IoT Device ID:</b> {iot_device()["deviceID"]} </h1>
+                    <h1 class='device-name'><b>IoT Device Name:</b> {iot_device()["deviceName"]} </h1>
                     <p class='poll-text'> Question: </p>
-                    <p class='poll-text'> {onePoll()["question"]} </p>
+                    <p class='poll-question'> {onePoll()["question"]} </p>
                     <Buttons />
                 </div>
             </div>
@@ -36,4 +36,3 @@ const Poll:Component = () => {
 }
 
 export default Poll;
-

--- a/iot/src/components/Poll.tsx
+++ b/iot/src/components/Poll.tsx
@@ -5,8 +5,7 @@ import NextPollButton from './button/NextPollButton';
 import { Component } from 'solid-js';
 
 function Poll() {
-
-    if (onePoll() !== undefined) {
+    if (onePoll() !== '' && onePoll() !== undefined) {
         return (
             <div class="container">
             <div class="poll">
@@ -26,8 +25,9 @@ function Poll() {
         <div class="container">
             <div class="poll">
                 <div class="poll-form">
+                <h1 class='device-id'><b>IoT Device ID:</b> {iot_device()["deviceID"]} </h1>
                     <h1 class='text-center'> IoT Device: {iot_device()["deviceName"]} </h1>
-                    <p class='poll-text'> Could not find more polls </p>
+                    <p class='poll-text'> Could not find any polls for this device. </p>
                 </div>
             </div>
         </div>

--- a/iot/src/components/Poll.tsx
+++ b/iot/src/components/Poll.tsx
@@ -4,7 +4,7 @@ import { onePoll, iot_device } from '../routes/Votescreen';
 import NextPollButton from './button/NextPollButton';
 import { Component } from 'solid-js';
 
-const Poll:Component = () => {
+function Poll() {
 
     if (onePoll() !== undefined) {
         return (

--- a/iot/src/components/SearchIoTDevice.css
+++ b/iot/src/components/SearchIoTDevice.css
@@ -11,7 +11,7 @@
 }
 
 .submit-iot-btn {
-    background-color: #42B6F3;
+    background-color: #34799e;
     color: white;
     border: none;
     padding: 15px 70px 15px 70px;
@@ -24,10 +24,11 @@
 }
 
 .submit-iot-btn:hover {
-    background-color: #0b3148;
+    background-color: #134b6e;
+    cursor: pointer;
 }
-
 .iot-search-input{
+    color: #42B6F3;
     height: 60px;
     width: 60%;
     display: block;
@@ -36,6 +37,9 @@
     margin-bottom: 30px;
     text-align: center;
     font-size: 30px;
+    border: 1px solid rgb(187, 187, 187);
+    border-radius: 10px;
+
 }
 
 .iot-search-input::placeholder {
@@ -43,7 +47,10 @@
     text-align: center;
     font-size: 30px;
 }
-
+.iot-search-input:focus{
+    outline: none;
+}
 .iot-search-input:focus::placeholder {
     color: transparent;
+    outline: #d400ff;
 }

--- a/iot/src/components/SearchIoTDevice.tsx
+++ b/iot/src/components/SearchIoTDevice.tsx
@@ -1,15 +1,12 @@
-import { id, setId, iot_device, setIot_device } from '../routes/Votescreen';
+import { id, setId, iot_device, setIot_device, setPoll, poll, setOnePoll, onePoll, setPoll_id, poll_id} from '../routes/Votescreen';
 import "./SearchIoTDevice.css";
 import { useNavigate } from '@solidjs/router';
 import axios from 'axios';
 import getPolls from '../components/Poll';
 import { Component, createEffect, createResource, createSignal } from 'solid-js';
-import { setPoll, poll, setOnePoll, onePoll, setPoll_id, poll_id } from '../routes/Votescreen';
-
 
 
 function SearchIoTDevice (){
-    
     const navigate = useNavigate();
     const handleChange = (e: any) => {
         setId(e.target.value);
@@ -17,23 +14,35 @@ function SearchIoTDevice (){
     }
 
     const handleSubmit = async () => {
-            const res = await axios.get(`https://localhost:7280/api/IoT/${id()}`);
+            const res = await axios.get(`${import.meta.env.VITE_BASE_URL}IoT/${id()}`).catch(err => err);
+            if(!res || !res.status){ return 400 }
             const data = await res.data;
             setIot_device(data);
+            navigate('/id');
+            return 200
     }
 
     const getPolls = async () => {
-        const res = await axios.get(`https://localhost:7280/api/IoT/servedPolls/${id()}`);
+        const res = await axios.get(`${import.meta.env.VITE_BASE_URL}IoT/servedPolls/${id()}`).catch(err => err);
+        if(!res || !res.status){return 400}
         const data = await res.data;
-        console.log("Polls", data);
         setPoll(data);
         setOnePoll(poll()[0]);
         setPoll_id(onePoll()["id"]);
+        return 200
     }
 
-    function onClick() {
-        handleSubmit();
-        getPolls();
+    async function onClick() {
+        const res = await handleSubmit();
+        if(res != 200){
+            alert('IoT device not found.')
+            return navigate('');
+        }
+        const res2 = await getPolls();
+        if(res2 != 200){
+            alert('An error occurred when fetching polls. Please try again.')
+            return navigate('')
+        }
         navigate('/id');
     }
 

--- a/iot/src/components/SearchIoTDevice.tsx
+++ b/iot/src/components/SearchIoTDevice.tsx
@@ -10,15 +10,15 @@ function SearchIoTDevice (){
     const navigate = useNavigate();
     const handleChange = (e: any) => {
         setId(e.target.value);
-        console.log("hello you", id());
     }
 
     const handleSubmit = async () => {
+            setPoll('');
+            setOnePoll('');
             const res = await axios.get(`${import.meta.env.VITE_BASE_URL}IoT/${id()}`).catch(err => err);
             if(!res || !res.status){ return 400 }
             const data = await res.data;
             setIot_device(data);
-            navigate('/id');
             return 200
     }
 
@@ -42,11 +42,13 @@ function SearchIoTDevice (){
             return navigate('');
         }
         const res2 = await getPolls();
-        if(res2 != 200){
-            alert('An error occurred when fetching polls. Please try again.')
+        if (res2 != 200){
+            alert('An error ocurred while fetching polls. Please try again.')
             return navigate('')
         }
-        navigate('/id');
+        if (res == 200 && res2 == 200){
+            return navigate('/id');
+        }
     }
 
     return (

--- a/iot/src/components/SearchIoTDevice.tsx
+++ b/iot/src/components/SearchIoTDevice.tsx
@@ -26,6 +26,9 @@ function SearchIoTDevice (){
         const res = await axios.get(`${import.meta.env.VITE_BASE_URL}IoT/servedPolls/${id()}`).catch(err => err);
         if(!res || !res.status){return 400}
         const data = await res.data;
+        if(data.length == 0){
+            return 200
+        }
         setPoll(data);
         setOnePoll(poll()[0]);
         setPoll_id(onePoll()["id"]);

--- a/iot/src/components/button/Button.css
+++ b/iot/src/components/button/Button.css
@@ -1,10 +1,11 @@
 .buttons {
     display: flex;
-    flex-direction: row;
-    justify-content: space-around;
+    flex-direction: column;
+    justify-content: center;
     align-items: center;
     width: 100%;
     height: 100%;
+    color: pink;
 }
 .btn {
     background-color: #42B6F3;
@@ -16,83 +17,77 @@
     font-size: 25px;
     margin: 4px 2px;
     border-radius: 12px;
+    box-shadow: 0 7px #15171a;
 }
 
 .vote-yes-btn {
-    background-color: #36e223;
-    color: black;
+    background-color: #24961a;
     border: none;
-    padding: 15px 70px 15px 70px;
+    padding: 180px;
     text-align: center;
     text-decoration: none;
-    font-size: 25px;
-    margin: 4px 2px;
+    font-size: 50px;
+    margin: 4px 10px;
     border-radius: 12px;
-    box-shadow: 0 9px #999;
+    box-shadow: 0 7px #15171a;
     border: none;
     border-radius: 15px;
 }
 
 .vote-yes-btn:hover {
-    background-color: #1f9013;
+    background-color: #1f8a11;
     cursor: pointer;
 }
 
 .vote-yes-btn:active {
-    background-color: #1f9013;
-    box-shadow: 0 5px #666;
+    background-color: #107a10;
     transform: translateY(4px);
 }
 
 
 .vote-no-btn {
-    background-color: #e22323;
-    color: black;
+    background-color: #961a1a;
     border: none;
-    padding: 15px 70px 15px 70px;
+    padding: 180px;
     text-align: center;
     text-decoration: none;
-    font-size: 25px;
-    margin: 4px 2px;
+    font-size: 50px;
+    margin: 4px 10px;
     border-radius: 12px;
-    box-shadow: 0 9px #999;
     border: none;
     border-radius: 15px;
 }
 
 .vote-no-btn:hover {
-    background-color: #a71c1c;
+    background-color: #8a1111;
     cursor: pointer;
 }
 
 .vote-no-btn:active {
-    background-color: #a71c1c;
-    box-shadow: 0 5px #666;
+    background-color: #7a1010;
     transform: translateY(4px);
 }
 
 .next-poll-btn {
-    background-color: #42B6F3;
+    background-color: #5e5e5e;
     color: white;
     border: none;
     padding: 15px 70px 15px 70px;
     text-align: center;
     text-decoration: none;
     font-size: 25px;
-    margin: 4px 2px;
+    margin: 20px 0px;
     border-radius: 12px;
-    box-shadow: 0 9px #999;
     border: none;
     border-radius: 15px;
 }
 
 .next-poll-btn:hover {
-    background-color: #2b6c93;
+    background-color: #575757;
     cursor: pointer;
 }
 
 .next-poll-btn:active {
     background-color: #2b6c93;
-    box-shadow: 0 5px #666;
     transform: translateY(4px);
 }

--- a/iot/src/components/button/Buttons.tsx
+++ b/iot/src/components/button/Buttons.tsx
@@ -9,9 +9,13 @@ const Buttons : Component = () => {
     
     return (
         <div class='buttons'> 
-            <VoteYesButton />
-            <VoteNoButton />
-            <NextPollButton />
+            <div>
+                <VoteNoButton />
+                <VoteYesButton />
+            </div>
+            <div>
+                <NextPollButton />
+            </div>
         </div>
     )
 };

--- a/iot/src/components/button/NextPollButton.tsx
+++ b/iot/src/components/button/NextPollButton.tsx
@@ -1,22 +1,24 @@
 import { Component, createSignal } from "solid-js";
 import './Button.css'
-import { setOnePoll, poll, setPoll_id, onePoll, poll_id  } from '../../routes/Votescreen';
+import Votescreen, { setOnePoll, setPoll, poll, setPoll_id, onePoll, poll_id  } from '../../routes/Votescreen';
 import axios from 'axios';
+import { useNavigate } from '@solidjs/router';
 const [count, setCount] = createSignal(0);
 
 const NextPollButton: Component = () => {
-
-    
-    const nextPoll = async () => {
+    const navigate = useNavigate();
+    async function onClick(){
+        if(count() >= poll().length-1){
+            //todo make it display the could not find more polls message.
+            return console.log('No more polls :)')
+        }
         setCount(count() + 1);
         setOnePoll(poll()[count()]);
         setPoll_id(onePoll()["id"]);
-        console.log("poll_id", poll_id());
-        console.log("onePoll", onePoll());
         }
 
     return (
-        <button class="next-poll-btn btn" onClick={nextPoll}> Next Poll </button>
+        <button class="next-poll-btn btn" onClick={onClick}> Next Poll </button>
     )
 };   
 export default NextPollButton;

--- a/iot/src/components/button/NextPollButton.tsx
+++ b/iot/src/components/button/NextPollButton.tsx
@@ -9,7 +9,10 @@ const NextPollButton: Component = () => {
     const navigate = useNavigate();
     async function onClick(){
         if(count() >= poll().length-1){
-            //todo make it display the could not find more polls message.
+            
+            setCount(0);
+            alert("Could not find more polls, redirecting to home screen");
+            navigate('/');
             return console.log('No more polls :)')
         }
         setCount(count() + 1);

--- a/iot/src/components/button/NextPollButton.tsx
+++ b/iot/src/components/button/NextPollButton.tsx
@@ -25,3 +25,4 @@ const NextPollButton: Component = () => {
     )
 };   
 export default NextPollButton;
+export {count, setCount}

--- a/iot/src/components/button/VoteNoButton.tsx
+++ b/iot/src/components/button/VoteNoButton.tsx
@@ -6,7 +6,7 @@ import axios from 'axios';
 const VoteNoButton: Component = () => {
     const voteNo = async () => {
         console.log("Poll sin id", poll_id());
-        const res = await axios.post(`https://localhost:7280/api/vote/${poll_id()}`, {
+        const res = await axios.post(`${import.meta.env.VITE_BASE_URL}vote/${poll_id()}`, {
             "isPositive": false
         }) 
     }

--- a/iot/src/components/button/VoteNoButton.tsx
+++ b/iot/src/components/button/VoteNoButton.tsx
@@ -1,14 +1,40 @@
-import { Component } from "solid-js";
+import { Component, createSignal } from "solid-js";
 import './Button.css'
-import { poll_id } from '../../routes/Votescreen';
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
+import Votescreen, { setOnePoll, setPoll, poll, setPoll_id, onePoll, poll_id, iot_device} from '../../routes/Votescreen';
+import { useNavigate } from '@solidjs/router';
+import {count, setCount} from './NextPollButton'
+
 
 const VoteNoButton: Component = () => {
+    const navigate = useNavigate();
+    async function nextPoll(){
+        //Move to next poll
+        if(count() >= poll().length-1){
+            setCount(0);
+            alert("Could not find more polls, redirecting to home screen");
+            navigate('/');
+            return console.log('No more polls :)')
+        }
+        setCount(count() + 1);
+        setOnePoll(poll()[count()]);
+        setPoll_id(onePoll()["id"]);
+    }
+
     const voteNo = async () => {
-        console.log("Poll sin id", poll_id());
+        if(!poll_id()){return nextPoll()} //In this case it returns to '/'.
+        //Vote
         const res = await axios.post(`${import.meta.env.VITE_BASE_URL}vote/${poll_id()}`, {
             "isPositive": false
-        }) 
+        }).catch(err => err)
+        if(!res || !res.status){return console.log('Something went wrong')}
+        if(res.status != 201){return console.log(res.statusText)}
+        
+        //Remove poll from served polls
+        const removePoll = await axios.post(`${import.meta.env.VITE_BASE_URL}iot/servedPolls/${iot_device()["deviceID"]}/${poll_id()}`).catch(err => err)
+        if(!removePoll || !removePoll.status){return}
+        if(removePoll.status != 200){return console.log(res.statusText)}
+        return nextPoll();
     }
     return (
             <button class="vote-no-btn btn" onClick={voteNo}> No </button>

--- a/iot/src/components/button/VoteYesButton.tsx
+++ b/iot/src/components/button/VoteYesButton.tsx
@@ -1,19 +1,42 @@
-import { Component } from "solid-js";
+import { Component, createSignal } from "solid-js";
 import './Button.css'
-import axios from 'axios';
-import { poll_id } from '../../routes/Votescreen';
+import axios, { AxiosResponse } from 'axios';
+import Votescreen, { setOnePoll, setPoll, poll, setPoll_id, onePoll, poll_id, iot_device} from '../../routes/Votescreen';
+import { useNavigate } from '@solidjs/router';
+import {count, setCount} from './NextPollButton'
+
+
 
 const VoteYesButton: Component = () => {
-    const voteYes = async () => {
-        console.log("Poll sin id", poll_id());
-        const res = await axios.post(`${import.meta.env.VITE_BASE_URL}vote/${poll_id()}`, {
-            "isPositive": true
-        })
-        const data = await res.data.status;
-        console.log(data);
-        console.log("Ja");  
-
+    const navigate = useNavigate();
+    async function nextPoll(){
+        //Move to next poll
+        if(count() >= poll().length-1){
+            setCount(0);
+            alert("Could not find more polls, redirecting to home screen");
+            navigate('/');
+            return console.log('No more polls :)')
+        }
+        setCount(count() + 1);
+        setOnePoll(poll()[count()]);
+        setPoll_id(onePoll()["id"]);
     }
+
+    async function voteYes(){
+        if(!poll_id()){return nextPoll()} //In this case it returns to '/'.
+        //Vote
+        const res:AxiosResponse = await axios.post(`${import.meta.env.VITE_BASE_URL}vote/${poll_id()}`, {
+            "isPositive": true
+        }).catch(err => err)
+        if(!res || !res.status){return console.log('Something went wrong')}
+        if(res.status != 201){return console.log(res.statusText)}
+
+        //Remove poll from served polls
+        const removePoll = await axios.post(`${import.meta.env.VITE_BASE_URL}iot/servedPolls/${iot_device()["deviceID"]}/${poll_id()}`).catch(err => err)
+        if(!removePoll || !removePoll.status){return}
+        if(removePoll.status != 200){return console.log(res.statusText)}
+        return nextPoll();
+        }
     return (
         <button class="vote-yes-btn btn" onClick={voteYes}> Yes </button>
     )

--- a/iot/src/components/button/VoteYesButton.tsx
+++ b/iot/src/components/button/VoteYesButton.tsx
@@ -6,7 +6,7 @@ import { poll_id } from '../../routes/Votescreen';
 const VoteYesButton: Component = () => {
     const voteYes = async () => {
         console.log("Poll sin id", poll_id());
-        const res = await axios.post(`https://localhost:7280/api/vote/${poll_id()}`, {
+        const res = await axios.post(`${import.meta.env.VITE_BASE_URL}vote/${poll_id()}`, {
             "isPositive": true
         })
         const data = await res.data.status;

--- a/iot/src/index.css
+++ b/iot/src/index.css
@@ -5,8 +5,17 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: #26292e;
+  background-color: #26292e;
+}
+button, input, select, textarea {
+  background-color: #1c1f24;
+  color: #bfbfbf;
 }
 
+font, html {
+  color: #bfbfbf;
+}
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;

--- a/iot/src/routes/Votescreen.tsx
+++ b/iot/src/routes/Votescreen.tsx
@@ -12,7 +12,6 @@ const [onePoll, setOnePoll] = createSignal('');
 const [poll_id, setPoll_id] = createSignal('');
 
 function Votescreen (){
-
     return (
         <div>
             <Poll />


### PR DESCRIPTION
## Handle errors on invalid IoT Guid, design changes(Don't MERGE)

Added logic to handle invalid response on selecting IoT by id. Changed the UI to be more intuitive (green button on right side, red on left) as well as making some big changes to the overall design of the page. 

Added a quick fix for when queue is empty. It displays an alert message to user and redirects them to the start screen. 

## Todo:
Need to handle errors on voting as well as figure out how to handle when the queue is empty, for now i avoided error by simply returning if this is the case, see NextPollButton.tsx. Note that navigating to / works, so it takes you back to the start screen, however /id does not seem to do anything.
In terms of backend I will add a check tomorrow to see if a vote is performed by an IoT device and if so remove it from the IoT poll queue. I will also add functionality to closePoll so that when a poll closes it is removed from all IoT queues OR remove a poll from IoT queue if an IoT device attempts to vote on a closed poll.